### PR TITLE
Docs: Add manual pages configuration (fixes #41)

### DIFF
--- a/adapt-authoring.json
+++ b/adapt-authoring.json
@@ -1,5 +1,9 @@
 {
   "documentation": {
-    "enable": true
+    "enable": true,
+    "manualPages": {
+      "aut-permissions.md": "basics",
+      "creating-auth-plugins.md": "advanced"
+    }
   }
 }


### PR DESCRIPTION
fixes #41

### Docs
* Add manual pages configuration mapping `aut-permissions.md` to basics and `creating-auth-plugins.md` to advanced documentation sections

### Testing
1. Verify documentation builds correctly with the new manual pages configuration