### PR TITLE
Fix: Initialise permissions before sessions

### DIFF
--- a/lib/AuthModule.js
+++ b/lib/AuthModule.js
@@ -44,15 +44,16 @@ class AuthModule extends AbstractModule {
      */
     this.router = server.api.createChildRouter('auth')
 
-    this.initSessions(mongodb, server)
-
-    server.root.addHandlerMiddleware(this.rootMiddleware.bind(this))
-    server.api.addHandlerMiddleware(this.apiMiddleware.bind(this))
     /**
      * The permission-checking unit
      * @type {Permissions}
      */
     this.permissions = await Permissions.init(this)
+
+    this.initSessions(mongodb, server)
+
+    server.root.addHandlerMiddleware(this.rootMiddleware.bind(this))
+    server.api.addHandlerMiddleware(this.apiMiddleware.bind(this))
     /**
      * The authentication unit
      * @type {Authentication}


### PR DESCRIPTION
## Summary
- `initSessions()` calls `this.secureRoute()` which accesses `this.permissions.secureRoute()`, but `this.permissions` was not initialised until after the `initSessions()` call
- Moved `this.permissions = await Permissions.init(this)` before `this.initSessions()` to fix the `TypeError: Cannot read properties of undefined (reading 'secureRoute')` on startup

## Test plan
- [ ] Verify app starts without `TypeError` on `this.permissions.secureRoute`
- [ ] Verify session routes are secured correctly
- [ ] Verify auth flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)