### PR TITLE
Chore: Use mock.module() for server stub instead of file: mock (fixes #77)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "repository": "github:adapt-security/adapt-authoring-auth",
   "scripts": {
-    "test": "node --test 'tests/**/*.spec.js'"
+    "test": "node --experimental-test-module-mocks --test 'tests/**/*.spec.js'"
   },
   "dependencies": {
     "adapt-authoring-core": "^3.0.0",
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@adaptlearning/semantic-release-config": "^1.0.0",
-    "adapt-authoring-server": "file:./tests/mocks/adapt-authoring-server",
     "standard": "^17.1.0"
   },
   "release": {

--- a/tests/AbstractAuthModule.spec.js
+++ b/tests/AbstractAuthModule.spec.js
@@ -1,10 +1,17 @@
-import { describe, it, before, after } from 'node:test'
+import { describe, it, before, after, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdir, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Hook } from 'adapt-authoring-core'
-import AbstractAuthModule from '../lib/AbstractAuthModule.js'
+
+mock.module('adapt-authoring-server', {
+  namedExports: {
+    loadRouteConfig: async () => null,
+    registerRoutes: () => {}
+  }
+})
+const { default: AbstractAuthModule } = await import('../lib/AbstractAuthModule.js')
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const MODULE_ROOT = path.join(__dirname, '..')

--- a/tests/Authentication.spec.js
+++ b/tests/Authentication.spec.js
@@ -1,8 +1,15 @@
-import { describe, it, before, after } from 'node:test'
+import { describe, it, before, after, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { App, Hook } from 'adapt-authoring-core'
-import Authentication from '../lib/Authentication.js'
-import AbstractAuthModule from '../lib/AbstractAuthModule.js'
+
+mock.module('adapt-authoring-server', {
+  namedExports: {
+    loadRouteConfig: async () => null,
+    registerRoutes: () => {}
+  }
+})
+const { default: Authentication } = await import('../lib/Authentication.js')
+const { default: AbstractAuthModule } = await import('../lib/AbstractAuthModule.js')
 
 function createMockApp () {
   const moduleLoadedHook = new Hook()

--- a/tests/mocks/adapt-authoring-server/index.js
+++ b/tests/mocks/adapt-authoring-server/index.js
@@ -1,2 +1,0 @@
-export async function loadRouteConfig () { return null }
-export function registerRoutes () {}

--- a/tests/mocks/adapt-authoring-server/package.json
+++ b/tests/mocks/adapt-authoring-server/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "adapt-authoring-server",
-  "version": "2.0.0",
-  "type": "module",
-  "main": "index.js",
-  "exports": {
-    ".": "./index.js"
-  }
-}


### PR DESCRIPTION
### Fixes #77

### Chore
* Replace the `file:./tests/mocks/adapt-authoring-server` devDependency with `mock.module('adapt-authoring-server', …)` in `AbstractAuthModule.spec.js` and `Authentication.spec.js`, matching the project's documented test-mock convention (as used in `adapt-authoring-auth-local`)
* Add `--experimental-test-module-mocks` to the `test` script (required for `mock.module`)
* Remove the now-unused `tests/mocks/` stub package

### Testing
1. `npm test` — 112 tests pass