### PR TITLE
Fix: Set saveUninitialized: false to prevent logout on page reload

### DIFF
--- a/lib/AuthModule.js
+++ b/lib/AuthModule.js
@@ -72,7 +72,7 @@ class AuthModule extends AbstractModule {
         name: 'adapt.user_session',
         resave: false,
         rolling: this.getConfig('sessionRolling'),
-        saveUninitialized: true,
+        saveUninitialized: false,
         secret: this.getConfig('sessionSecret'),
         unset: 'destroy',
         cookie: {


### PR DESCRIPTION
### Fixes #79

### Fix
- Set `saveUninitialized: false` in `initSessions()` — express-session no longer mints and persists an empty session (with `Set-Cookie`) for requests that arrive without a session cookie, which was overwriting the authenticated cookie on Firefox session-restored tab reloads