### PR TITLE
New: expose configured session middleware as auth.sessionMiddleware

### DIFF
--- a/lib/AuthModule.js
+++ b/lib/AuthModule.js
@@ -67,27 +67,25 @@ class AuthModule extends AbstractModule {
    * @param {Object} server The server module instance
    */
   initSessions (mongodb, server) {
-    server.expressApp.use(
-      session({
-        name: 'adapt.user_session',
-        resave: false,
-        rolling: this.getConfig('sessionRolling'),
-        saveUninitialized: false,
-        secret: this.getConfig('sessionSecret'),
-        unset: 'destroy',
-        cookie: {
-          maxAge: this.getConfig('sessionLifespan'),
-          sameSite: this.getConfig('sessionSameSite'),
-          secure: this.getConfig('sessionSecure')
-        },
-        store: MongoDBStore.create({
-          client: mongodb.client,
-          collection: this.getConfig('sessionCollection'),
-          stringify: false
-        })
-      }),
-      this.storeAuthHeader
-    )
+    this.sessionMiddleware = session({
+      name: 'adapt.user_session',
+      resave: false,
+      rolling: this.getConfig('sessionRolling'),
+      saveUninitialized: false,
+      secret: this.getConfig('sessionSecret'),
+      unset: 'destroy',
+      cookie: {
+        maxAge: this.getConfig('sessionLifespan'),
+        sameSite: this.getConfig('sessionSameSite'),
+        secure: this.getConfig('sessionSecure')
+      },
+      store: MongoDBStore.create({
+        client: mongodb.client,
+        collection: this.getConfig('sessionCollection'),
+        stringify: false
+      })
+    })
+    server.expressApp.use(this.sessionMiddleware, this.storeAuthHeader)
     this.secureRoute('/api/session/clear', 'post', ['clear:session'])
   }
 


### PR DESCRIPTION
### New
- Store the configured `express-session` middleware on `AuthModule#sessionMiddleware` so other servers can reuse the exact same session configuration instead of reconstructing it. The motivating case is a socket.io server authenticating its handshake against the same session via `io.engine.use(auth.sessionMiddleware)`, then reading `req.session.token`.
- No behavioural change to the Express app: the same middleware instance is still applied via `server.expressApp.use(this.sessionMiddleware, this.storeAuthHeader)`, and `/api/session/clear` is still secured.

### Testing
- `npx standard` passes.
- Single source of truth for session config (secret, cookie name, store) — consumers no longer need to duplicate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)