### PR TITLE
Fix: resolve adapt-authoring-server in tests so mocks work in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@adaptlearning/semantic-release-config": "^1.0.0",
+    "adapt-authoring-server": "^2.1.0",
     "standard": "^17.1.0"
   },
   "release": {

--- a/tests/AuthModule.spec.js
+++ b/tests/AuthModule.spec.js
@@ -1,7 +1,14 @@
-import { describe, it } from 'node:test'
+import { describe, it, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { Hook } from 'adapt-authoring-core'
-import AuthModule from '../lib/AuthModule.js'
+
+mock.module('adapt-authoring-server', {
+  namedExports: {
+    loadRouteConfig: async () => null,
+    registerRoutes: () => {}
+  }
+})
+const { default: AuthModule } = await import('../lib/AuthModule.js')
 
 function createMockApp () {
   const moduleLoadedHook = new Hook()


### PR DESCRIPTION
### Chore
- The `AuthModule`, `Authentication`, and `AbstractAuthModule` specs unit-test code paths that import `adapt-authoring-server` (`loadRouteConfig` / `registerRoutes`) and mock it with `mock.module('adapt-authoring-server', …)`. But `mock.module()` can only intercept a specifier that **resolves**, and `adapt-authoring-server` is a `peerDependency` that CI's `npm install` doesn't install — so the mock can't register and the specs fail with `ERR_MODULE_NOT_FOUND`. (Locally they pass only because the umbrella workspace hoists the package.)
- Add `adapt-authoring-server` as a **devDependency** so the specifier resolves in CI and the existing mocks work.
- Convert `AuthModule.spec.js` from a static top-of-file `import` to `mock.module(…)` + `await import('../lib/AuthModule.js')`, matching `Authentication.spec.js` / `AbstractAuthModule.spec.js`.

This fixes the pre-existing red **Tests** check on `master` (same `MODULE_NOT_FOUND` cause), unrelated to #81.

### Testing
- `npm test` — 112/112 pass.
- `npx standard` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)