### PR TITLE
New: Add scoped auth tokens and block super-admin token creation (fixes #85)

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -127,6 +127,17 @@ The recommended way to declare route scopes is a `routes.json` file, or the `rou
 
 Scope checks answer *"may this user call this endpoint at all?"* They cannot express *"which records may this user see?"* — that is what the access hooks below are for.
 
+## Scoped tokens
+
+`req.auth.scopes` is normally the union of the user's role scopes (above). A token may instead be **scoped** — restricted at mint time to a subset of those scopes — in which case the request carries only that subset:
+
+- `AuthToken.generate(authType, user, { scopes })` persists the given `scopes` on the token, validated as a subset of the user's own (a super user, holding all scopes, may request any concrete set). `initRequestData` then narrows `req.auth.scopes` to that set and recomputes `isSuper` on it — so a scoped token is never a super token.
+- Omitting `scopes` yields an ordinary token that inherits the user's full role scopes at verification time (this is what login tokens do).
+
+Scoped tokens let a trusted server-side caller mint a narrow credential for a user — e.g. a token limited to `read:content`/`write:content` for an external service — without handing over the user's full authority.
+
+**Super users cannot create elevated tokens.** A super user (`*:*`) may not mint a full-scope bearer token: `POST /auth/generatetoken` is refused for them, and `AuthToken.generate` rejects a `manual` token for a super user, or any `scopes` containing the `*:*` wildcard. A super user may still be issued a *scoped* (non-super) token, and their interactive login session is unaffected.
+
 ## Per-record access: the access hooks
 
 Scopes are coarse: `read:content` lets a user hit `GET /api/content`, but a user should usually only see *their own* (or shared) courses, not everyone's. `AbstractApiModule` exposes two hooks for this fine-grained filtering. Both are skipped for super users.

--- a/errors/errors.json
+++ b/errors/errors.json
@@ -55,6 +55,17 @@
     "description": "Authorization headers are missing from request",
     "statusCode": 401
   },
+  "SUPER_TOKEN_FORBIDDEN": {
+    "description": "Super users cannot create tokens carrying elevated privileges",
+    "statusCode": 403
+  },
+  "TOKEN_SCOPE_INVALID": {
+    "data": {
+      "scopes": "The requested scopes that exceed the user's own"
+    },
+    "description": "Requested token scopes exceed the user's own scopes",
+    "statusCode": 403
+  },
   "UNAUTHENTICATED": {
     "description": "Request is not authenticated for access to the API",
     "statusCode": 401

--- a/lib/AuthToken.js
+++ b/lib/AuthToken.js
@@ -2,6 +2,7 @@ import { App } from 'adapt-authoring-core'
 import { createObjectId } from 'adapt-authoring-mongodb'
 import jwt from 'jsonwebtoken'
 import { promisify } from 'node:util'
+import { resolveTokenScopes } from './utils/resolveTokenScopes.js'
 
 /** @ignore */ const jwtSignPromise = promisify(jwt.sign)
 /** @ignore */ const jwtVerifyPromise = promisify(jwt.verify)
@@ -54,9 +55,10 @@ class AuthToken {
         .setData({ authType: user.authType })
     }
     const userSchemaName = authPlugin.userSchema
-    await mongodb.update(collectionName, { signature: token.signature }, { $set: { usedAt: new Date() } })
+    const tokenRecord = await mongodb.update(collectionName, { signature: token.signature }, { $set: { usedAt: new Date() } })
 
-    const scopes = [].concat(...(await Promise.all(user.roles.map(r => roles.getScopesForRole(r)))))
+    const roleScopes = [].concat(...(await Promise.all(user.roles.map(r => roles.getScopesForRole(r)))))
+    const scopes = Array.isArray(tokenRecord?.scopes) ? tokenRecord.scopes : roleScopes
     const isSuper = this.isSuper(scopes)
 
     Object.assign(req.auth, { isSuper, scopes, token, user, userSchemaName })
@@ -77,12 +79,22 @@ class AuthToken {
    * @param {Object} userData The user to be encoded
    * @param {Object} options
    * @param {string} options.lifespan Lifespan of the token
+   * @param {Array<string>} [options.scopes] Restrict the token to a subset of the user's scopes; omit to inherit the user's full scopes. May not include the super wildcard.
    * @return {Promise} Resolves with the token value
    */
   static async generate (authType, userData, options = {}) {
     const [auth, jsonschema, mongodb] = await App.instance.waitForModule('auth', 'jsonschema', 'mongodb')
     const _id = createObjectId().toString()
     const expiresIn = options.lifespan ?? App.instance.config.get('adapt-authoring-auth.defaultTokenLifespan')
+
+    // login tokens skip the roles lookup and inherit the full scope set at verification time
+    let scopes
+    if (authType === 'manual' || options.scopes !== undefined) {
+      const roles = await App.instance.waitForModule('roles')
+      const userScopes = [].concat(...(await Promise.all((userData.roles ?? []).map(r => roles.getScopesForRole(r)))))
+      scopes = resolveTokenScopes({ authType, userScopes, requestedScopes: options.scopes }, App.instance.errors)
+    }
+
     const token = await jwtSignPromise({ sub: userData.email, type: authType }, this.secret, {
       expiresIn,
       issuer: App.instance.config.get('adapt-authoring-auth.tokenIssuer')
@@ -93,7 +105,8 @@ class AuthToken {
       authType,
       signature: this.getSignature(token),
       createdAt: new Date().toISOString(),
-      userId: userData._id.toString()
+      userId: userData._id.toString(),
+      ...(scopes !== undefined ? { scopes } : {})
     })
     await mongodb.insert(collectionName, data)
     auth.log('debug', 'AUTH_TOKEN_ISSUED', data.userId.toString(), data.authType, expiresIn)

--- a/lib/Authentication.js
+++ b/lib/Authentication.js
@@ -159,6 +159,9 @@ class Authentication {
    */
   async generateTokenHandler (req, res, next) {
     try {
+      if (req.auth.isSuper) {
+        throw App.instance.errors.SUPER_TOKEN_FORBIDDEN
+      }
       res.json({ token: await AuthToken.generate('manual', req.auth.user, { lifespan: req.body.lifespan }) })
     } catch (e) {
       return next(e)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,2 +1,3 @@
 export { createEmptyStore } from './utils/createEmptyStore.js'
 export { initAuthData } from './utils/initAuthData.js'
+export { resolveTokenScopes } from './utils/resolveTokenScopes.js'

--- a/lib/utils/resolveTokenScopes.js
+++ b/lib/utils/resolveTokenScopes.js
@@ -1,0 +1,35 @@
+/**
+ * Decides the scopes to persist on a new auth token, enforcing the token-scope rules:
+ * a super user may not mint a `manual` (full-scope, copy-pasteable) bearer token; explicit
+ * scopes may never include the super wildcard, and — for non-super users — may not exceed
+ * the user's own scopes (a super holds all scopes, so may request any concrete set).
+ * @param {object} params
+ * @param {string} params.authType Authentication type of the token being generated
+ * @param {Array<string>} params.userScopes The user's role-derived scopes
+ * @param {Array<string>} [params.requestedScopes] Explicit scopes for a scoped token; omit to inherit the user's full scopes
+ * @param {object} errors Error registry (App.instance.errors) used to throw
+ * @returns {Array<string>|undefined} Scopes to persist on the token, or undefined to inherit the user's full scopes
+ * @memberof auth
+ */
+export function resolveTokenScopes ({ authType, userScopes, requestedScopes }, errors) {
+  const isSuper = userScopes.length === 1 && userScopes[0] === '*:*'
+  if (isSuper && authType === 'manual') {
+    throw errors.SUPER_TOKEN_FORBIDDEN
+  }
+  if (requestedScopes === undefined) {
+    return undefined
+  }
+  if (!Array.isArray(requestedScopes)) {
+    throw errors.INVALID_PARAMS.setData({ params: ['scopes'] })
+  }
+  if (requestedScopes.includes('*:*')) {
+    throw errors.SUPER_TOKEN_FORBIDDEN
+  }
+  if (!isSuper) {
+    const invalid = requestedScopes.filter(s => !userScopes.includes(s))
+    if (invalid.length) {
+      throw errors.TOKEN_SCOPE_INVALID.setData({ scopes: invalid })
+    }
+  }
+  return requestedScopes
+}

--- a/schema/authtoken.schema.json
+++ b/schema/authtoken.schema.json
@@ -33,6 +33,12 @@
       "description": "Type of authentication used with this token",
       "type": "string",
       "isReadOnly": true
+    },
+    "scopes": {
+      "description": "Scopes this token is restricted to; when set, the request is limited to these instead of the user's full role-derived scopes",
+      "type": "array",
+      "items": { "type": "string" },
+      "isReadOnly": true
     }
   },
   "required": ["signature", "userId", "createdAt", "authType"]

--- a/tests/utils-resolveTokenScopes.spec.js
+++ b/tests/utils-resolveTokenScopes.spec.js
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveTokenScopes } from '../lib/utils/resolveTokenScopes.js'
+
+/**
+ * Fake error registry: each entry is a throwable carrying its code, with a
+ * chainable setData() mirroring App.instance.errors — so the pure util can be
+ * tested without App.instance.
+ */
+function makeErrors () {
+  const mk = code => {
+    const e = new Error(code)
+    e.code = code
+    e.setData = function (data) { this.data = data; return this }
+    return e
+  }
+  return {
+    SUPER_TOKEN_FORBIDDEN: mk('SUPER_TOKEN_FORBIDDEN'),
+    INVALID_PARAMS: mk('INVALID_PARAMS'),
+    TOKEN_SCOPE_INVALID: mk('TOKEN_SCOPE_INVALID')
+  }
+}
+
+const byCode = code => err => err.code === code
+
+describe('resolveTokenScopes()', () => {
+  const errors = makeErrors()
+
+  describe('login / inherited-scope tokens (no requestedScopes)', () => {
+    it('returns undefined for a normal user (inherit full scopes)', () => {
+      const result = resolveTokenScopes({ authType: 'local', userScopes: ['read:content', 'write:content'] }, errors)
+      assert.equal(result, undefined)
+    })
+
+    it('returns undefined for a super user logging in (super may hold a session token)', () => {
+      const result = resolveTokenScopes({ authType: 'local', userScopes: ['*:*'] }, errors)
+      assert.equal(result, undefined)
+    })
+
+    it('returns undefined for a non-super manual token (self-service token still works)', () => {
+      const result = resolveTokenScopes({ authType: 'manual', userScopes: ['read:content'] }, errors)
+      assert.equal(result, undefined)
+    })
+  })
+
+  describe('super-admin manual token block', () => {
+    it('throws SUPER_TOKEN_FORBIDDEN when a super user mints a manual token', () => {
+      assert.throws(
+        () => resolveTokenScopes({ authType: 'manual', userScopes: ['*:*'] }, errors),
+        byCode('SUPER_TOKEN_FORBIDDEN')
+      )
+    })
+
+    it('a user with *:* plus other scopes is not super, so may mint a manual token', () => {
+      const result = resolveTokenScopes({ authType: 'manual', userScopes: ['*:*', 'read:content'] }, errors)
+      assert.equal(result, undefined)
+    })
+  })
+
+  describe('scoped tokens', () => {
+    it('returns the requested scopes when they are a subset of the user\'s', () => {
+      const result = resolveTokenScopes(
+        { authType: 'blueprint', userScopes: ['read:content', 'write:content', 'read:users'], requestedScopes: ['read:content', 'write:content'] },
+        errors
+      )
+      assert.deepEqual(result, ['read:content', 'write:content'])
+    })
+
+    it('lets a super user request any concrete scopes (super holds all)', () => {
+      const result = resolveTokenScopes(
+        { authType: 'blueprint', userScopes: ['*:*'], requestedScopes: ['read:content', 'write:content'] },
+        errors
+      )
+      assert.deepEqual(result, ['read:content', 'write:content'])
+    })
+
+    it('throws TOKEN_SCOPE_INVALID when a non-super requests scopes it lacks', () => {
+      assert.throws(
+        () => resolveTokenScopes(
+          { authType: 'blueprint', userScopes: ['read:content'], requestedScopes: ['read:content', 'write:users'] },
+          errors
+        ),
+        err => {
+          assert.equal(err.code, 'TOKEN_SCOPE_INVALID')
+          assert.deepEqual(err.data, { scopes: ['write:users'] })
+          return true
+        }
+      )
+    })
+
+    it('never lets a scoped token carry the super wildcard, even for a super user', () => {
+      assert.throws(
+        () => resolveTokenScopes({ authType: 'blueprint', userScopes: ['*:*'], requestedScopes: ['*:*'] }, errors),
+        byCode('SUPER_TOKEN_FORBIDDEN')
+      )
+    })
+
+    it('throws INVALID_PARAMS when requestedScopes is not an array', () => {
+      assert.throws(
+        () => resolveTokenScopes({ authType: 'blueprint', userScopes: ['read:content'], requestedScopes: 'read:content' }, errors),
+        byCode('INVALID_PARAMS')
+      )
+    })
+
+    it('returns an empty array unchanged (an explicitly no-access token)', () => {
+      const result = resolveTokenScopes({ authType: 'blueprint', userScopes: ['read:content'], requestedScopes: [] }, errors)
+      assert.deepEqual(result, [])
+    })
+  })
+})


### PR DESCRIPTION
### Fixes #85

### New
* `AuthToken.generate(authType, user, { scopes })` mints a token restricted to a subset of the user's scopes, validated via a new pure `resolveTokenScopes` util (a super may request any concrete scopes; the `*:*` wildcard is rejected). The scopes are persisted on the `authtoken` row (schema updated) and `initRequestData` narrows `req.auth.scopes` to them, recomputing `isSuper` — so a scoped token is never a super token.
* Block super admins from creating elevated tokens: `generateTokenHandler` refuses `req.auth.isSuper`, and `generate()` rejects a `manual` token for a super user (new `SUPER_TOKEN_FORBIDDEN` error). Login (`generate(this.type, …)`, no scopes) and scoped tokens are unaffected; existing super-held `manual` tokens are left to expire naturally.
* Document scoped tokens and the super-admin restriction in `docs/access-control.md`.

### Testing
1. `npx standard`
2. `npm test` — 123 pass, including the new `resolveTokenScopes` suite (subset validation, scope narrowing, super never leaks through a scoped token, super blocked from manual tokens, login/non-super paths unaffected).