### PR TITLE
Update: default sessionSecure to 'auto'

### DIFF
--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -65,9 +65,9 @@
       }
     },
     "sessionSecure": {
-      "description": "If true, cookie is only sent to the server when a request is made with the https scheme",
+      "description": "Controls the Secure flag on the session cookie: 'auto' (default) sets it only when the request is detected as https, true always sets it (breaks plain http), false never sets it. Behind a TLS-terminating reverse proxy, 'auto' requires adapt-authoring-server.trustProxy to be set so the https connection is detected.",
       "type": ["boolean", "string"],
-      "default": false
+      "default": "auto"
     }
   },
   "required": ["tokenSecret", "sessionSecret"]


### PR DESCRIPTION
### Update
- Change the `sessionSecure` config default from `false` to `'auto'`, so the session cookie's `Secure` flag is set automatically whenever the connection is detected as https, while still working over plain http (dev). This is a strict improvement over the previous `false` default and is non-breaking.
- Expand the schema description to document the `'auto'`/`true`/`false` semantics and the coupling: behind a TLS-terminating reverse proxy, `'auto'` relies on `adapt-authoring-server.trustProxy` being set so the https connection is detected.

Addresses the session-cookie `Secure`-flag finding in cgkineo/adapt-authoring#85. The umbrella's production defaults additionally set `trustProxy: 1` so `'auto'` resolves to secure behind the Apache proxy.