### PR TITLE
Fix: require authentication for the API endpoint map

### DIFF
--- a/docs/auth-permissions.md
+++ b/docs/auth-permissions.md
@@ -298,6 +298,14 @@ async init () {
 }
 ```
 
+**Requiring authentication without a specific scope:**
+
+Pass an empty scopes array to secure a route to *any* authenticated user while requiring no particular scope. Unauthenticated requests are still rejected; authenticated ones pass regardless of their roles. This differs from unsecuring, which allows anonymous access. The `GET /api` endpoint map uses this so only logged-in users can enumerate the API surface.
+
+```javascript
+auth.secureRoute('/api', 'get', [])
+```
+
 ### Access control hooks
 
 Although a user may have access to a resource, there may be occasions when more fine-grained control is necessary to filter out specific resources. In this case, you can use hooks to implement custom access control logic.

--- a/lib/AuthModule.js
+++ b/lib/AuthModule.js
@@ -50,6 +50,9 @@ class AuthModule extends AbstractModule {
      */
     this.permissions = await Permissions.init(this)
 
+    // the API endpoint map is available to any authenticated user (empty scopes = no specific scope required)
+    this.secureRoute('/api', 'get', [])
+
     this.initSessions(mongodb, server)
 
     server.root.addHandlerMiddleware(this.rootMiddleware.bind(this))


### PR DESCRIPTION
### Fixes #89

### Fix
- Secured `GET /api` (the endpoint map) with an empty scopes array — `secureRoute("/api", "get", [])` — so it requires authentication but no specific scope. Any logged-in user may enumerate the API surface; anonymous callers are rejected. Depends on adapt-security/adapt-authoring-server#69, which routes the map through the auth chain.

### Docs
- Documented the empty-scopes ("authenticated, no specific scope") pattern in `docs/auth-permissions.md`, which previously only covered scoped and unsecured routes.

### Testing
- `npx standard` clean; `npm test` 123/123 passing.
- Verified live: `GET /api` returns 401 unauthenticated (was 200); permissions matcher confirmed to allow an authenticated non-super user through empty scopes.