### PR TITLE
Fix: allow scope-restricted tokens to log out (fixes #91)

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -45,8 +45,8 @@ export default {
         shortName: 'authuser',
         displayName: 'Authenticated user',
         scopes: [
-          'disavow:auth', 'read:config', 'read:lang',
-          'read:me', 'write:me', 'clear:session'
+          'read:config', 'read:lang',
+          'read:me', 'write:me'
         ]
       },
       {

--- a/docs/auth-permissions.md
+++ b/docs/auth-permissions.md
@@ -106,12 +106,10 @@ Authorisation determines what authenticated users are allowed to do. The system 
 Roles are collections of scopes (permissions) assigned to users. The system comes with three default roles:
 
 **authuser** — Basic authenticated user:
-- `clear:session`
 - `read:config`
 - `read:lang`
 - `read:me`
 - `write:me`
-- `disavow:auth`
   
 **contentcreator** _extends authuser_ — Can create and manage content:
 - `preview:adapt`

--- a/docs/auth-permissions.md
+++ b/docs/auth-permissions.md
@@ -69,6 +69,8 @@ To log out or invalidate sessions and revoke the current user's token:
 POST /api/auth/disavow
 ```
 
+This endpoint requires only that the request is authenticated — it carries no scope requirement. Logging out revokes the caller's own token and destroys its session, so any valid token, including a scope-restricted one that lacks broader permissions, can always disavow itself.
+
 ### Disabling authentication
 
 For development only, authentication can be disabled.

--- a/lib/AuthModule.js
+++ b/lib/AuthModule.js
@@ -89,7 +89,6 @@ class AuthModule extends AbstractModule {
       })
     })
     server.expressApp.use(this.sessionMiddleware, this.storeAuthHeader)
-    this.secureRoute('/api/session/clear', 'post', ['clear:session'])
   }
 
   /**

--- a/routes.json
+++ b/routes.json
@@ -41,7 +41,7 @@
     {
       "route": "/disavow",
       "handlers": { "post": "disavowHandler" },
-      "permissions": { "post": ["disavow:auth"] },
+      "permissions": { "post": [] },
       "meta": {
         "post": {
           "summary": "De-authenticates the current user from the API",


### PR DESCRIPTION
### Fixes #91

### Fix

- `POST /api/auth/disavow` is now authenticated-only (an empty scopes array) instead of requiring the `disavow:auth` scope. A scope-restricted token whose scopes omit `disavow:auth` previously received a 403 on logout and could never revoke itself or destroy its session — logout was a silent no-op. Disavow only ever affects the caller's own token (by its signature) and session, so it is self-authorising and needs no specific scope. This was latent until scope-restricted tokens existed: every token used to carry the user's full role-derived scopes (which include `disavow:auth`), so disavow always passed.

### Docs

- `auth-permissions.md`: noted that disavow carries no scope requirement and that any valid token, including a scope-restricted one, can always disavow itself.

### Testing

- `Permissions.check` treats an empty required-scopes array as vacuously satisfied (`[].every(...) === true`), so any authenticated request passes while an unauthenticated one is still rejected — the same convention already used for the `GET /api` endpoint map.
- Verified end-to-end against a running server: a token restricted to `["read:content", "read:contentplugins", "read:schema", "write:content"]` returned `403 UNAUTHORISED` on `POST /api/auth/disavow` (leaving the token valid) before the change; after it, the request is accepted and the token and session are torn down.

### Chore

- Removed the dead `secureRoute('/api/session/clear', 'post', ['clear:session'])` in `AuthModule` — no handler is registered for that route anywhere, so it guarded nothing.
- Dropped the now-unreferenced `disavow:auth` and `clear:session` scopes from the example role definitions in the docs. (The default role definitions that ship these scopes live in `adapt-authoring-roles`; that change is handled separately.)
