### PR TITLE
Update: persistent sessions off by default + lifespan fix (fixes #93)

### DIFF
--- a/.claude/.github-write-ack/5a1ff4c12078c64860e39074d2bd7403.json
+++ b/.claude/.github-write-ack/5a1ff4c12078c64860e39074d2bd7403.json
@@ -1,0 +1,1 @@
+{"repo":"adapt-security/adapt-authoring-auth","kind":"git-push","branch":"fix-disavow-scope","ts":1783945166400}

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -46,8 +46,14 @@
       "isTimeMs": true,
       "default": "1h"
     },
+    "allowPersistentSessions": {
+      "description": "Whether users may keep a longer session that survives browser restarts (a 'remember me' option at login). Off by default: leaving it disabled limits every session to the sessionLifespan idle timeout, which is safer on shared machines. When disabled, a client requesting a persistent session is ignored.",
+      "type": "boolean",
+      "default": false,
+      "_adapt": { "isPublic": true }
+    },
     "persistentSessionLifespan": {
-      "description": "Idle timeout applied instead of sessionLifespan when a user opts to persist ('remember me') at login, so the session survives browser restarts and lasts longer. Should be greater than sessionLifespan.",
+      "description": "Idle timeout applied instead of sessionLifespan when a user opts to persist ('remember me') at login, so the session survives browser restarts and lasts longer. Only used when allowPersistentSessions is enabled. Should be greater than sessionLifespan.",
       "type": "string",
       "isTimeMs": true,
       "default": "14d"

--- a/conf/config.schema.json
+++ b/conf/config.schema.json
@@ -41,10 +41,16 @@
       "default": "usersessions"
     },
     "sessionLifespan": {
-      "description": "The amount of time a session should remain valid",
+      "description": "How long a standard session stays valid without activity (the rolling idle timeout). Applies to sessions that were not persisted via 'remember me'.",
       "type": "string",
       "isTimeMs": true,
       "default": "1h"
+    },
+    "persistentSessionLifespan": {
+      "description": "Idle timeout applied instead of sessionLifespan when a user opts to persist ('remember me') at login, so the session survives browser restarts and lasts longer. Should be greater than sessionLifespan.",
+      "type": "string",
+      "isTimeMs": true,
+      "default": "14d"
     },
     "sessionRolling": {
       "description": "Whether sessions should only expire after a period of inactivity",

--- a/lib/AbstractAuthModule.js
+++ b/lib/AbstractAuthModule.js
@@ -183,8 +183,8 @@ class AbstractAuthModule extends AbstractModule {
       await this.authenticate(user, req, res)
 
       if (req.session) {
-        // 'remember me' extends the rolling idle window to persistentSessionLifespan (longer, survives restarts); a standard session keeps the default sessionLifespan.
-        if (persistSession === true) {
+        // 'remember me' extends the rolling idle window to persistentSessionLifespan (longer, survives restarts); a standard session keeps the default sessionLifespan. Persistent sessions are opt-in per deployment via allowPersistentSessions.
+        if (persistSession === true && this.auth.getConfig('allowPersistentSessions')) {
           req.session.cookie.maxAge = this.auth.getConfig('persistentSessionLifespan')
           this.log('debug', 'NEW_SESSION', user._id)
         }

--- a/lib/AbstractAuthModule.js
+++ b/lib/AbstractAuthModule.js
@@ -183,9 +183,11 @@ class AbstractAuthModule extends AbstractModule {
       await this.authenticate(user, req, res)
 
       if (req.session) {
-        if (persistSession !== true) req.session.cookie.maxAge = null
-        else this.log('debug', 'NEW_SESSION', user._id)
-
+        // 'remember me' extends the rolling idle window to persistentSessionLifespan (longer, survives restarts); a standard session keeps the default sessionLifespan.
+        if (persistSession === true) {
+          req.session.cookie.maxAge = this.auth.getConfig('persistentSessionLifespan')
+          this.log('debug', 'NEW_SESSION', user._id)
+        }
         req.session.token = await AuthToken.generate(this.type, user)
       }
       res.status(204).json()

--- a/tests/AbstractAuthModule.spec.js
+++ b/tests/AbstractAuthModule.spec.js
@@ -418,31 +418,37 @@ describe('AbstractAuthModule', () => {
       }
     })
 
-    it('should extend the session to persistentSessionLifespan when persisting', async () => {
+    /** Runs authenticateHandler for a persistSession:true login with the given auth config, returns the resulting session maxAge. */
+    async function runPersistLogin (authConfig) {
       const module = new AbstractAuthModule(createMockApp(), { name: 'test-auth' })
-      const user = { _id: '123', email: 'test@test.com' }
-      module.users = { findOne: () => user }
+      module.users = { findOne: () => ({ _id: '123', email: 'test@test.com' }) }
       module.authenticate = async () => {}
       module.log = () => {}
-      module.auth = { getConfig: (key) => key === 'persistentSessionLifespan' ? 1209600000 : undefined }
-
+      module.auth = { getConfig: (key) => authConfig[key] }
       const req = {
         body: { email: 'test@test.com', persistSession: true },
         session: { cookie: { maxAge: 3600 }, token: null }
       }
       const res = { status: () => res, json: () => {} }
-
       const { default: AuthToken } = await import('../lib/AuthToken.js')
       const originalGenerate = AuthToken.generate
       AuthToken.generate = async () => 'mock-token'
-
       try {
         await module.authenticateHandler(req, res, () => {})
-        assert.equal(req.session.cookie.maxAge, 1209600000)
-        assert.equal(req.session.token, 'mock-token')
+        return req.session.cookie.maxAge
       } finally {
         AuthToken.generate = originalGenerate
       }
+    }
+
+    it('should extend to persistentSessionLifespan when persisting is allowed', async () => {
+      const maxAge = await runPersistLogin({ allowPersistentSessions: true, persistentSessionLifespan: 1209600000 })
+      assert.equal(maxAge, 1209600000)
+    })
+
+    it('should ignore a persistent-session request when not allowed', async () => {
+      const maxAge = await runPersistLogin({ allowPersistentSessions: false, persistentSessionLifespan: 1209600000 })
+      assert.equal(maxAge, 3600)
     })
 
     it('should send error if authenticate throws', async () => {

--- a/tests/AbstractAuthModule.spec.js
+++ b/tests/AbstractAuthModule.spec.js
@@ -410,7 +410,35 @@ describe('AbstractAuthModule', () => {
         await module.authenticateHandler(req, res, () => {})
         assert.equal(statusCode, 204)
         assert.equal(jsonCalled, true)
-        assert.equal(req.session.cookie.maxAge, null)
+        // a standard (non-persisted) session keeps its default idle window
+        assert.equal(req.session.cookie.maxAge, 3600)
+        assert.equal(req.session.token, 'mock-token')
+      } finally {
+        AuthToken.generate = originalGenerate
+      }
+    })
+
+    it('should extend the session to persistentSessionLifespan when persisting', async () => {
+      const module = new AbstractAuthModule(createMockApp(), { name: 'test-auth' })
+      const user = { _id: '123', email: 'test@test.com' }
+      module.users = { findOne: () => user }
+      module.authenticate = async () => {}
+      module.log = () => {}
+      module.auth = { getConfig: (key) => key === 'persistentSessionLifespan' ? 1209600000 : undefined }
+
+      const req = {
+        body: { email: 'test@test.com', persistSession: true },
+        session: { cookie: { maxAge: 3600 }, token: null }
+      }
+      const res = { status: () => res, json: () => {} }
+
+      const { default: AuthToken } = await import('../lib/AuthToken.js')
+      const originalGenerate = AuthToken.generate
+      AuthToken.generate = async () => 'mock-token'
+
+      try {
+        await module.authenticateHandler(req, res, () => {})
+        assert.equal(req.session.cookie.maxAge, 1209600000)
         assert.equal(req.session.token, 'mock-token')
       } finally {
         AuthToken.generate = originalGenerate


### PR DESCRIPTION
### Fixes #93

### Update

- **Persistent sessions ("remember me") are now opt-in per deployment, off by default**, via a new `allowPersistentSessions` config. When disabled (the default), a client requesting a persistent session is ignored and every session uses the standard `sessionLifespan` idle timeout — safer on shared machines. `allowPersistentSessions` is exposed to the client (`isPublic`) so the UI can hide the "remember me" control when it's disabled.

### Fix

- Stop nulling `req.session.cookie.maxAge` for a standard login. Setting it to `null` made the cookie a browser-session cookie *and* nulled `originalMaxAge`, so `rolling` had nothing to slide — a standard session had **no idle timeout** and outlived a "remember me" one. Now a standard session keeps the default `sessionLifespan` rolling idle window, and (when allowed) "remember me" extends it to `persistentSessionLifespan` (default `14d`) so it lasts longer and survives browser restarts.
- Because `maxAge` is now always set, the session cookie's expiry also bounds the store record, instead of standard sessions falling back to the store's default TTL.

### New

- `allowPersistentSessions` (boolean, default `false`) — whether "remember me" is offered at all.
- `persistentSessionLifespan` (default `14d`) — the idle window used for a persisted session, when allowed.

### Testing

- Verified the underlying cookie behaviour with a minimal express-session harness: `maxAge = null` emits a session cookie with no expiry and never re-adds one under `rolling`, whereas a kept `maxAge` slides on each response.
- `authenticateHandler` unit tests: a non-persisted login keeps its default `maxAge`; a persisted login is extended to `persistentSessionLifespan` **only when `allowPersistentSessions` is true**, and is ignored when false. Full suite passes (32/32); `standard` clean.

### Notes

- Behaviour change on upgrade: "remember me" stops taking effect until a deployment sets `allowPersistentSessions: true`, and a standard session is now a rolling `sessionLifespan` (default 1h) session (survives a restart within that idle window) rather than a browser-session cookie with no idle timeout. Both changes are stricter/safer than before; flagging in case a deployment relied on the old behaviour.
- UI counterpart (hide the "remember me" checkbox when disabled) is a separate change in the UI package.
