### PR TITLE
Fix: forward requested scopes through the generatetoken endpoint (fixes #95)

### DIFF
--- a/.claude/.github-write-ack/5a1ff4c12078c64860e39074d2bd7403.json
+++ b/.claude/.github-write-ack/5a1ff4c12078c64860e39074d2bd7403.json
@@ -1,1 +1,0 @@
-{"repo":"adapt-security/adapt-authoring-auth","kind":"git-push","branch":"fix-disavow-scope","ts":1783945166400}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+.claude/.github-write-ack/

--- a/lib/Authentication.js
+++ b/lib/Authentication.js
@@ -162,7 +162,7 @@ class Authentication {
       if (req.auth.isSuper) {
         throw App.instance.errors.SUPER_TOKEN_FORBIDDEN
       }
-      res.json({ token: await AuthToken.generate('manual', req.auth.user, { lifespan: req.body.lifespan }) })
+      res.json({ token: await AuthToken.generate('manual', req.auth.user, { lifespan: req.body.lifespan, scopes: req.body.scopes }) })
     } catch (e) {
       return next(e)
     }

--- a/routes.json
+++ b/routes.json
@@ -62,7 +62,10 @@
                 "schema": {
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
-                  "properties": { "lifespan": { "type": "string" } }
+                  "properties": {
+                    "lifespan": { "type": "string" },
+                    "scopes": { "type": "array", "items": { "type": "string" }, "description": "Restrict the token to a subset of the user's own scopes; omit to inherit the user's full scopes." }
+                  }
                 }
               }
             }

--- a/tests/Authentication.spec.js
+++ b/tests/Authentication.spec.js
@@ -158,6 +158,29 @@ describe('Authentication', () => {
     })
   })
 
+  describe('#generateTokenHandler()', () => {
+    it('should forward the requested lifespan and scopes to AuthToken.generate', async () => {
+      const authentication = new Authentication()
+      const { default: AuthToken } = await import('../lib/AuthToken.js')
+      const originalGenerate = AuthToken.generate
+      let captured
+      AuthToken.generate = async (authType, user, options) => { captured = { authType, options }; return 'tok' }
+
+      const req = { auth: { isSuper: false, user: { _id: '1', email: 'a@b.c' } }, body: { lifespan: '1d', scopes: ['read:content'] } }
+      let json
+      const res = { json: (x) => { json = x } }
+
+      try {
+        await authentication.generateTokenHandler(req, res, () => {})
+        assert.equal(captured.authType, 'manual')
+        assert.deepEqual(captured.options, { lifespan: '1d', scopes: ['read:content'] })
+        assert.deepEqual(json, { token: 'tok' })
+      } finally {
+        AuthToken.generate = originalGenerate
+      }
+    })
+  })
+
   describe('static #init()', () => {
     it('should be a static method', () => {
       assert.equal(typeof Authentication.init, 'function')


### PR DESCRIPTION
### Fixes #95

### Fix

- Forward `req.body.scopes` from `generateTokenHandler` into `AuthToken.generate`, and declare `scopes` in the `/generatetoken` request-body schema. The token layer already supports scope-restricted tokens (`resolveTokenScopes`), but the endpoint dropped the field, so every manual token minted via the API inherited the user's full scopes with no way to request a narrower one.
- Backwards-compatible: omitting `scopes` behaves exactly as before (full scopes). No new authorisation surface — `resolveTokenScopes` already rejects `*:*`, forbids a super user minting a manual token, and rejects scopes exceeding a non-super user's own (`TOKEN_SCOPE_INVALID`).

### Chore

- Removed a stray `.claude/.github-write-ack/*.json` file that was accidentally committed to this repo (via an over-broad `git add` in #94) and gitignored just that artifact directory (`.claude/.github-write-ack/`, not all of `.claude/`, since some `.claude` files are committed intentionally). The file was harmless tooling metadata (`{repo, kind, branch, ts}` — no secrets), just clutter.

### Testing

- Added a `generateTokenHandler` unit test asserting the requested `lifespan` and `scopes` are forwarded to `AuthToken.generate`. Full suite passes; `standard` clean.
