### PR TITLE
New: personal access token management API (fixes #97)

### DIFF
--- a/.claude/.github-write-ack/5a1ff4c12078c64860e39074d2bd7403.json
+++ b/.claude/.github-write-ack/5a1ff4c12078c64860e39074d2bd7403.json
@@ -1,1 +1,0 @@
-{"repo":"adapt-security/adapt-authoring-auth","kind":"git-push","branch":"fix-disavow-scope","ts":1783945166400}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+.claude/.github-write-ack/

--- a/errors/errors.json
+++ b/errors/errors.json
@@ -56,7 +56,7 @@
     "statusCode": 401
   },
   "SUPER_TOKEN_FORBIDDEN": {
-    "description": "Super users cannot create tokens carrying elevated privileges",
+    "description": "Super users cannot create a token that inherits or carries the super scope; specify explicit scopes instead",
     "statusCode": 403
   },
   "TOKEN_SCOPE_INVALID": {

--- a/lib/AuthToken.js
+++ b/lib/AuthToken.js
@@ -168,9 +168,9 @@ class AuthToken {
     if (!tokenData.sub) {
       throw App.instance.errors.INVALID_PARAMS.setData({ params: ['sub'] })
     }
-    try { // verify we have a matching token in the DB
-      await this.find({ signature: this.getSignature(jwtValue) })
-    } catch (e) {
+    // verify we have a matching token in the DB
+    const [record] = await this.find({ signature: this.getSignature(jwtValue) })
+    if (!record) {
       throw App.instance.errors.UNAUTHENTICATED
     }
     return tokenData
@@ -181,16 +181,12 @@ class AuthToken {
    * @param {Object} query
    * @param {Object} options
    * @param {Object} options.sanitise Whether the token data should be sanitised for returning via an API
-   * @return {Promise} Resolves with the value from MongoDBModule#find
+   * @return {Promise<Array>} Resolves with the matching tokens (an empty array when none match)
    */
   static async find (query, options = {}) {
     const [jsonschema, mongodb] = await App.instance.waitForModule('jsonschema', 'mongodb')
     const results = await mongodb.find(collectionName, query)
 
-    if (!results.length) {
-      throw App.instance.errors.NOT_FOUND
-        .setData({ type: 'authtoken', id: JSON.stringify(query) })
-    }
     if (!options.sanitise) {
       return results
     }
@@ -208,12 +204,8 @@ class AuthToken {
    */
   static async revoke (query) {
     const [auth, mongodb] = await App.instance.waitForModule('auth', 'mongodb')
-    try {
-      const results = await this.find(query)
-      results.forEach(r => auth.log('debug', 'AUTH_TOKEN_REVOKED', r.userId.toString(), r.authType))
-    } catch (e) {
-      return // just fail silently if token doesn't exist
-    }
+    const results = await this.find(query)
+    results.forEach(r => auth.log('debug', 'AUTH_TOKEN_REVOKED', r.userId.toString(), r.authType))
     return mongodb.getCollection(collectionName).deleteMany(query)
   }
 }

--- a/lib/AuthToken.js
+++ b/lib/AuthToken.js
@@ -2,6 +2,7 @@ import { App } from 'adapt-authoring-core'
 import { createObjectId } from 'adapt-authoring-mongodb'
 import jwt from 'jsonwebtoken'
 import { promisify } from 'node:util'
+import { randomBytes } from 'node:crypto'
 import { resolveTokenScopes } from './utils/resolveTokenScopes.js'
 
 /** @ignore */ const jwtSignPromise = promisify(jwt.sign)
@@ -9,6 +10,7 @@ import { resolveTokenScopes } from './utils/resolveTokenScopes.js'
 
 /** @ignore */ const collectionName = 'authtokens'
 /** @ignore */ const schemaName = 'authtoken'
+/** @ignore */ const tokenPrefix = 'adpt_pat_'
 /**
  * Utilities for dealing with JSON web tokens
  * @memberof auth
@@ -24,6 +26,21 @@ class AuthToken {
 
   static getSignature (token) {
     return token.split('.')[2]
+  }
+
+  /**
+   * Strips the personal-access-token prefix (`adpt_pat_<frag>_`) from a token value,
+   * returning the bare JWT. A value without the prefix (e.g. a session token) is returned unchanged.
+   * @param {String} value The incoming token value
+   * @return {String} The bare JWT
+   */
+  static stripTokenPrefix (value) {
+    if (!value.startsWith(tokenPrefix)) {
+      return value
+    }
+    const rest = value.slice(tokenPrefix.length)
+    const sep = rest.indexOf('_')
+    return sep === -1 ? rest : rest.slice(sep + 1)
   }
 
   /**
@@ -78,14 +95,16 @@ class AuthToken {
    * @param {String} authType Authentication type used
    * @param {Object} userData The user to be encoded
    * @param {Object} options
-   * @param {string} options.lifespan Lifespan of the token
+   * @param {string} [options.lifespan] Lifespan of the token; pass `'never'` for a non-expiring token
+   * @param {string} [options.name] Human-readable label for a personal access token
    * @param {Array<string>} [options.scopes] Restrict the token to a subset of the user's scopes; omit to inherit the user's full scopes. May not include the super wildcard.
-   * @return {Promise} Resolves with the token value
+   * @return {Promise} Resolves with the token value (personal access tokens are prefixed `adpt_pat_` and returned only once)
    */
   static async generate (authType, userData, options = {}) {
     const [auth, jsonschema, mongodb] = await App.instance.waitForModule('auth', 'jsonschema', 'mongodb')
     const _id = createObjectId().toString()
-    const expiresIn = options.lifespan ?? App.instance.config.get('adapt-authoring-auth.defaultTokenLifespan')
+    const noExpiry = options.lifespan === 'never'
+    const expiresIn = noExpiry ? undefined : (options.lifespan ?? App.instance.config.get('adapt-authoring-auth.defaultTokenLifespan'))
 
     // login tokens skip the roles lookup and inherit the full scope set at verification time
     let scopes
@@ -96,9 +115,15 @@ class AuthToken {
     }
 
     const token = await jwtSignPromise({ sub: userData.email, type: authType }, this.secret, {
-      expiresIn,
+      ...(expiresIn !== undefined ? { expiresIn } : {}),
       issuer: App.instance.config.get('adapt-authoring-auth.tokenIssuer')
     })
+    // personal access tokens carry a random-fragment prefix so the stored hint distinguishes
+    // them (a bare JWT always starts `eyJ`); the full value is returned only once
+    const isManual = authType === 'manual'
+    const fragment = isManual ? randomBytes(4).toString('hex') : undefined
+    const value = isManual ? `${tokenPrefix}${fragment}_${token}` : token
+    const exp = jwt.decode(token)?.exp
     const schema = await jsonschema.getSchema(schemaName)
     const data = schema.validate({
       _id,
@@ -106,11 +131,14 @@ class AuthToken {
       signature: this.getSignature(token),
       createdAt: new Date().toISOString(),
       userId: userData._id.toString(),
-      ...(scopes !== undefined ? { scopes } : {})
+      ...(scopes !== undefined ? { scopes } : {}),
+      ...(options.name ? { name: options.name } : {}),
+      ...(isManual ? { hint: `${tokenPrefix}${fragment}…` } : {}),
+      ...(exp ? { expiresAt: new Date(exp * 1000).toISOString() } : {})
     })
     await mongodb.insert(collectionName, data)
-    auth.log('debug', 'AUTH_TOKEN_ISSUED', data.userId.toString(), data.authType, expiresIn)
-    return token
+    auth.log('debug', 'AUTH_TOKEN_ISSUED', data.userId.toString(), data.authType, expiresIn ?? 'never')
+    return value
   }
 
   /**
@@ -119,10 +147,11 @@ class AuthToken {
    * @return {Promise} Decoded token data
    */
   static async decode (token) {
+    const jwtValue = this.stripTokenPrefix(token)
     let tokenData
     try {
-      tokenData = await jwtVerifyPromise(token, this.secret)
-      tokenData.signature = this.getSignature(token)
+      tokenData = await jwtVerifyPromise(jwtValue, this.secret)
+      tokenData.signature = this.getSignature(jwtValue)
     } catch (e) {
       switch (e.name) {
         case 'JsonWebTokenError':
@@ -130,7 +159,7 @@ class AuthToken {
         case 'NotBeforeError':
           throw App.instance.errors.AUTH_TOKEN_NOT_BEFORE.setData({ error: e.message })
         case 'TokenExpiredError':
-          try { await this.revoke({ signature: this.getSignature(token) }) } catch {}
+          try { await this.revoke({ signature: this.getSignature(jwtValue) }) } catch {}
           throw App.instance.errors.AUTH_TOKEN_EXPIRED
         default:
           throw App.instance.errors.AUTH_TOKEN_INVALID.setData({ error: e.message })
@@ -140,7 +169,7 @@ class AuthToken {
       throw App.instance.errors.INVALID_PARAMS.setData({ params: ['sub'] })
     }
     try { // verify we have a matching token in the DB
-      await this.find({ signature: this.getSignature(token) })
+      await this.find({ signature: this.getSignature(jwtValue) })
     } catch (e) {
       throw App.instance.errors.UNAUTHENTICATED
     }
@@ -165,8 +194,11 @@ class AuthToken {
     if (!options.sanitise) {
       return results
     }
+    // strict:false strips internal fields (e.g. signature) from the output; the
+    // default strict throws MODIFY_PROTECTED_ATTR when a protected field is present.
+    // _id isn't a declared schema property, so carry it through for the API consumer.
     const schema = await jsonschema.getSchema(schemaName)
-    return results.map(r => schema.sanitise(r, { isInternal: true }))
+    return results.map(r => ({ _id: r._id, ...schema.sanitise(r, { isInternal: true, strict: false }) }))
   }
 
   /**

--- a/lib/Authentication.js
+++ b/lib/Authentication.js
@@ -1,4 +1,5 @@
 import { App, readJson } from 'adapt-authoring-core'
+import { parseObjectId } from 'adapt-authoring-mongodb'
 import { registerRoutes } from 'adapt-authoring-server'
 import AuthToken from './AuthToken.js'
 import AbstractAuthModule from './AbstractAuthModule.js'
@@ -159,10 +160,7 @@ class Authentication {
    */
   async generateTokenHandler (req, res, next) {
     try {
-      if (req.auth.isSuper) {
-        throw App.instance.errors.SUPER_TOKEN_FORBIDDEN
-      }
-      res.json({ token: await AuthToken.generate('manual', req.auth.user, { lifespan: req.body.lifespan, scopes: req.body.scopes }) })
+      res.json({ token: await AuthToken.generate('manual', req.auth.user, { name: req.body.name, lifespan: req.body.lifespan, scopes: req.body.scopes }) })
     } catch (e) {
       return next(e)
     }
@@ -176,7 +174,28 @@ class Authentication {
    */
   async retrieveTokensHandler (req, res, next) {
     try {
-      res.json(await AuthToken.find({ userId: req.auth.user._id }, { sanitise: true }))
+      // only personal access tokens (authType 'manual') — session/login tokens aren't managed here.
+      // find throws NOT_FOUND on an empty match, so map that to an empty list for the API consumer.
+      const tokens = await AuthToken
+        .find({ userId: req.auth.user._id, authType: 'manual' }, { sanitise: true })
+        .catch(e => { if (e.code === 'NOT_FOUND') return []; throw e })
+      res.json(tokens)
+    } catch (e) {
+      return next(e)
+    }
+  }
+
+  /**
+   * Revokes a single token owned by the current user
+   * @param {external:ExpressRequest} req
+   * @param {external:ExpressResponse} res
+   * @param {Function} next
+   */
+  async revokeTokenHandler (req, res, next) {
+    try {
+      // scope the revoke to the current user's own token so one user can't delete another's
+      await AuthToken.revoke({ _id: parseObjectId(req.params._id), userId: req.auth.user._id })
+      res.status(204).end()
     } catch (e) {
       return next(e)
     }

--- a/lib/Authentication.js
+++ b/lib/Authentication.js
@@ -174,11 +174,8 @@ class Authentication {
    */
   async retrieveTokensHandler (req, res, next) {
     try {
-      // only personal access tokens (authType 'manual') — session/login tokens aren't managed here.
-      // find throws NOT_FOUND on an empty match, so map that to an empty list for the API consumer.
-      const tokens = await AuthToken
-        .find({ userId: req.auth.user._id, authType: 'manual' }, { sanitise: true })
-        .catch(e => { if (e.code === 'NOT_FOUND') return []; throw e })
+      // only personal access tokens (authType 'manual') — session/login tokens aren't managed here
+      const tokens = await AuthToken.find({ userId: req.auth.user._id, authType: 'manual' }, { sanitise: true })
       res.json(tokens)
     } catch (e) {
       return next(e)

--- a/lib/Authentication.js
+++ b/lib/Authentication.js
@@ -162,7 +162,7 @@ class Authentication {
       if (req.auth.isSuper) {
         throw App.instance.errors.SUPER_TOKEN_FORBIDDEN
       }
-      res.json({ token: await AuthToken.generate('manual', req.auth.user, { lifespan: req.body.lifespan }) })
+      res.json({ token: await AuthToken.generate('manual', req.auth.user, { lifespan: req.body.lifespan, scopes: req.body.scopes }) })
     } catch (e) {
       return next(e)
     }

--- a/lib/utils/resolveTokenScopes.js
+++ b/lib/utils/resolveTokenScopes.js
@@ -1,8 +1,9 @@
 /**
  * Decides the scopes to persist on a new auth token, enforcing the token-scope rules:
- * a super user may not mint a `manual` (full-scope, copy-pasteable) bearer token; explicit
- * scopes may never include the super wildcard, and — for non-super users — may not exceed
- * the user's own scopes (a super holds all scopes, so may request any concrete set).
+ * a super user may mint a `manual` (copy-pasteable) bearer token but must name explicit
+ * scopes for it — one may never inherit or carry the super wildcard; explicit scopes may
+ * never include the super wildcard, and — for non-super users — may not exceed the user's
+ * own scopes (a super holds all scopes, so may request any concrete set).
  * @param {object} params
  * @param {string} params.authType Authentication type of the token being generated
  * @param {Array<string>} params.userScopes The user's role-derived scopes
@@ -13,10 +14,11 @@
  */
 export function resolveTokenScopes ({ authType, userScopes, requestedScopes }, errors) {
   const isSuper = userScopes.length === 1 && userScopes[0] === '*:*'
-  if (isSuper && authType === 'manual') {
-    throw errors.SUPER_TOKEN_FORBIDDEN
-  }
   if (requestedScopes === undefined) {
+    // a super manual token would otherwise inherit the super wildcard, so require explicit scopes
+    if (isSuper && authType === 'manual') {
+      throw errors.SUPER_TOKEN_FORBIDDEN
+    }
     return undefined
   }
   if (!Array.isArray(requestedScopes)) {

--- a/routes.json
+++ b/routes.json
@@ -63,7 +63,8 @@
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
                   "properties": {
-                    "lifespan": { "type": "string" },
+                    "name": { "type": "string", "description": "Human-readable label to distinguish this token." },
+                    "lifespan": { "type": "string", "description": "Token lifespan (e.g. '30d'); pass 'never' for a non-expiring token." },
                     "scopes": { "type": "array", "items": { "type": "string" }, "description": "Restrict the token to a subset of the user's own scopes; omit to inherit the user's full scopes." }
                   }
                 }
@@ -97,10 +98,15 @@
                     "type": "array",
                     "items": {
                       "properties": {
+                        "_id": { "type": "string" },
+                        "name": { "type": "string" },
                         "userId": { "type": "string" },
                         "createdAt": { "type": "string" },
                         "usedAt": { "type": "string" },
-                        "authType": { "type": "string" }
+                        "expiresAt": { "type": "string" },
+                        "authType": { "type": "string" },
+                        "hint": { "type": "string" },
+                        "scopes": { "type": "array", "items": { "type": "string" } }
                       }
                     }
                   }
@@ -108,6 +114,17 @@
               }
             }
           }
+        }
+      }
+    },
+    {
+      "route": "/tokens/:_id",
+      "handlers": { "delete": "revokeTokenHandler" },
+      "permissions": { "delete": ["read:me"] },
+      "meta": {
+        "delete": {
+          "summary": "Revoke a single authentication token owned by the current user",
+          "responses": { "204": {} }
         }
       }
     }

--- a/routes.json
+++ b/routes.json
@@ -62,7 +62,10 @@
                 "schema": {
                   "$schema": "https://json-schema.org/draft/2020-12/schema",
                   "type": "object",
-                  "properties": { "lifespan": { "type": "string" } }
+                  "properties": {
+                    "lifespan": { "type": "string" },
+                    "scopes": { "type": "array", "items": { "type": "string" }, "description": "Restrict the token to a subset of the user's own scopes; omit to inherit the user's full scopes." }
+                  }
                 }
               }
             }

--- a/schema/authtoken.schema.json
+++ b/schema/authtoken.schema.json
@@ -34,6 +34,22 @@
       "type": "string",
       "isReadOnly": true
     },
+    "name": {
+      "description": "Human-readable label to distinguish this token from the user's others",
+      "type": "string"
+    },
+    "expiresAt": {
+      "description": "Token expiry timestamp; absent when the token never expires",
+      "type": "string",
+      "format": "date-time",
+      "isDate": true,
+      "isReadOnly": true
+    },
+    "hint": {
+      "description": "Masked display prefix of the token (the full value is shown only once at creation)",
+      "type": "string",
+      "isReadOnly": true
+    },
     "scopes": {
       "description": "Scopes this token is restricted to; when set, the request is limited to these instead of the user's full role-derived scopes",
       "type": "array",

--- a/tests/AuthToken.spec.js
+++ b/tests/AuthToken.spec.js
@@ -77,6 +77,23 @@ describe('AuthToken', () => {
     })
   })
 
+  describe('#stripTokenPrefix()', () => {
+    it('returns a bare JWT (no prefix) unchanged, so session tokens still verify', () => {
+      const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.abc123def456'
+      assert.equal(AuthToken.stripTokenPrefix(jwt), jwt)
+    })
+
+    it('strips the adpt_pat_<frag>_ prefix from a personal access token, recovering the JWT', () => {
+      const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.abc123def456'
+      assert.equal(AuthToken.stripTokenPrefix(`adpt_pat_7f3ad0c1_${jwt}`), jwt)
+    })
+
+    it('splits only on the first separator, so a JWT containing underscores is preserved', () => {
+      const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdW_iOiJ0ZXN0In0.ab_c123_def456'
+      assert.equal(AuthToken.stripTokenPrefix(`adpt_pat_7f3ad0c1_${jwt}`), jwt)
+    })
+  })
+
   describe('.generate()', () => {
     it('should be a static method', () => {
       assert.equal(typeof AuthToken.generate, 'function')

--- a/tests/Authentication.spec.js
+++ b/tests/Authentication.spec.js
@@ -158,6 +158,29 @@ describe('Authentication', () => {
     })
   })
 
+  describe('#generateTokenHandler()', () => {
+    it('should forward the requested lifespan and scopes to AuthToken.generate', async () => {
+      const authentication = new Authentication()
+      const { default: AuthToken } = await import('../lib/AuthToken.js')
+      const originalGenerate = AuthToken.generate
+      let captured
+      AuthToken.generate = async (authType, user, options) => { captured = { authType, options }; return 'tok' }
+
+      const req = { auth: { isSuper: false, user: { _id: '1', email: 'a@b.c' } }, body: { lifespan: '1d', scopes: ['read:content'] } }
+      let json
+      const res = { json: (x) => { json = x } }
+
+      try {
+        await authentication.generateTokenHandler(req, res, () => {})
+        assert.equal(captured.authType, 'manual')
+        assert.deepEqual(captured.options, { lifespan: '1d', scopes: ['read:content'] })
+        assert.deepEqual(json, { token: 'tok' })
+      } finally {
+        AuthToken.generate = originalGenerate
+      }
+    })
+  })
+
   describe('static #init()', () => {
     it('should be a static method', () => {
       assert.equal(typeof Authentication.init, 'function')

--- a/tests/Authentication.spec.js
+++ b/tests/Authentication.spec.js
@@ -8,6 +8,12 @@ mock.module('adapt-authoring-server', {
     registerRoutes: () => {}
   }
 })
+mock.module('adapt-authoring-mongodb', {
+  namedExports: {
+    createObjectId: () => ({ _bsontype: 'ObjectId', toString: () => 'mock-oid' }),
+    parseObjectId: (v) => ({ _bsontype: 'ObjectId', value: v, toString: () => String(v) })
+  }
+})
 const { default: Authentication } = await import('../lib/Authentication.js')
 const { default: AbstractAuthModule } = await import('../lib/AbstractAuthModule.js')
 
@@ -159,24 +165,68 @@ describe('Authentication', () => {
   })
 
   describe('#generateTokenHandler()', () => {
-    it('should forward the requested lifespan and scopes to AuthToken.generate', async () => {
+    it('should forward the requested name, lifespan and scopes to AuthToken.generate', async () => {
       const authentication = new Authentication()
       const { default: AuthToken } = await import('../lib/AuthToken.js')
       const originalGenerate = AuthToken.generate
       let captured
       AuthToken.generate = async (authType, user, options) => { captured = { authType, options }; return 'tok' }
 
-      const req = { auth: { isSuper: false, user: { _id: '1', email: 'a@b.c' } }, body: { lifespan: '1d', scopes: ['read:content'] } }
+      const req = { auth: { isSuper: false, user: { _id: '1', email: 'a@b.c' } }, body: { name: 'CI deploy', lifespan: '1d', scopes: ['read:content'] } }
       let json
       const res = { json: (x) => { json = x } }
 
       try {
         await authentication.generateTokenHandler(req, res, () => {})
         assert.equal(captured.authType, 'manual')
-        assert.deepEqual(captured.options, { lifespan: '1d', scopes: ['read:content'] })
+        assert.deepEqual(captured.options, { name: 'CI deploy', lifespan: '1d', scopes: ['read:content'] })
         assert.deepEqual(json, { token: 'tok' })
       } finally {
         AuthToken.generate = originalGenerate
+      }
+    })
+
+    it('should no longer reject a super user outright (scope rules are enforced in AuthToken.generate)', async () => {
+      const authentication = new Authentication()
+      const { default: AuthToken } = await import('../lib/AuthToken.js')
+      const originalGenerate = AuthToken.generate
+      let called = false
+      AuthToken.generate = async () => { called = true; return 'tok' }
+
+      const req = { auth: { isSuper: true, user: { _id: '1', email: 'a@b.c' } }, body: { name: 'super token', scopes: ['read:content'] } }
+      let json
+      const res = { json: (x) => { json = x } }
+      let nextErr
+      try {
+        await authentication.generateTokenHandler(req, res, (e) => { nextErr = e })
+        assert.equal(called, true)
+        assert.equal(nextErr, undefined)
+        assert.deepEqual(json, { token: 'tok' })
+      } finally {
+        AuthToken.generate = originalGenerate
+      }
+    })
+  })
+
+  describe('#revokeTokenHandler()', () => {
+    it('should revoke the token scoped to the current user and respond 204', async () => {
+      const authentication = new Authentication()
+      const { default: AuthToken } = await import('../lib/AuthToken.js')
+      const originalRevoke = AuthToken.revoke
+      let query
+      AuthToken.revoke = async (q) => { query = q }
+
+      const req = { params: { _id: '507f1f77bcf86cd799439011' }, auth: { user: { _id: 'user-1' } } }
+      let statusCode
+      const res = { status: (c) => { statusCode = c; return { end: () => {} } } }
+
+      try {
+        await authentication.revokeTokenHandler(req, res, () => {})
+        assert.equal(query.userId, 'user-1')
+        assert.equal(query._id.value, '507f1f77bcf86cd799439011') // converted to an ObjectId so deleteMany matches the stored id
+        assert.equal(statusCode, 204)
+      } finally {
+        AuthToken.revoke = originalRevoke
       }
     })
   })

--- a/tests/utils-resolveTokenScopes.spec.js
+++ b/tests/utils-resolveTokenScopes.spec.js
@@ -55,6 +55,14 @@ describe('resolveTokenScopes()', () => {
       const result = resolveTokenScopes({ authType: 'manual', userScopes: ['*:*', 'read:content'] }, errors)
       assert.equal(result, undefined)
     })
+
+    it('lets a super user mint a manual token when explicit non-super scopes are given', () => {
+      const result = resolveTokenScopes(
+        { authType: 'manual', userScopes: ['*:*'], requestedScopes: ['read:content', 'write:content'] },
+        errors
+      )
+      assert.deepEqual(result, ['read:content', 'write:content'])
+    })
   })
 
   describe('scoped tokens', () => {


### PR DESCRIPTION
### Fixes #97
### Fixes #14
### Fixes #95

Supersedes #96 — this branch includes and extends that scope-forwarding change, so #96 can be closed in favour of this PR.

### New
- `name`, `expiresAt` and a masked `hint` on the `authtoken` schema.
- Personal access tokens are minted with an `adpt_pat_<fragment>_` prefix and the full value is returned only once; the stored `hint` lets the owner recognise a token in a listing without exposing it. `AuthToken.stripTokenPrefix()` strips the prefix before verification, so session tokens (unprefixed) are unaffected.
- `generateTokenHandler` forwards `name`, `lifespan` and `scopes` to `AuthToken.generate`. `lifespan: "never"` mints a non-expiring token; otherwise `expiresAt` is persisted from the token's expiry.
- `DELETE /tokens/:_id` revokes a single token owned by the current user (ownership-scoped by `_id` + `userId`).
- A super user may now mint a manual token, provided they supply explicit scopes that don't include the super wildcard (`*:*`); minting without scopes, or with `*:*`, still returns `SUPER_TOKEN_FORBIDDEN`.

### Fix
- `GET /tokens` no longer throws `MODIFY_PROTECTED_ATTR` (#14): the sanitise call now runs non-strict, so internal fields (e.g. `signature`) are stripped from the response rather than rejected. The listing also carries `_id`, is limited to personal (`manual`) tokens, and returns an empty array when there are none.
- Revoke-by-id used `createObjectId(id)`, which ignores its argument and mints a new random id, so the query matched nothing. Switched to `parseObjectId(id)`.

### Testing
- Unit tests for `resolveTokenScopes` (super-lift cases), `generateTokenHandler` (name/lifespan/scopes forwarded; super no longer rejected outright), `revokeTokenHandler` (ownership-scoped, id parsed to an ObjectId) and `stripTokenPrefix`. Full suite (132) passes; `standard` clean.
- End-to-end against a running server: super mint with/without scopes and with `*:*`; prefixed Bearer authentication and scope limiting; sanitised listing with `_id`; per-token revoke actually removing the record; revoked token rejected; empty listing.
